### PR TITLE
[chore]: commit lint 정규식 변경

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -13,7 +13,7 @@ module.exports = {
        *    (.+)$                   : 나머지(커밋 메시지 본문)를 캡처
        * - **주의:** Unicode property escapes (\p{Emoji})는 Node.js 12 이상에서 u 플래그와 함께 사용 가능합니다.
        */
-      headerPattern: /^((?:\p{Emoji})?[a-z]+)(?:\(([^)]+)\))?:\s(.+)$/u,
+      headerPattern: /^((?:[\p{Emoji}][\uFE0F]?)?[a-z]+)(?:\(([^)]+)\))?:\s(.+)$/u,
       headerCorrespondence: ['type', 'scope', 'subject'],
     },
   },


### PR DESCRIPTION
## [chore] commit lint 정규식 변경

## 설명
- refactor의 이모티콘이 단일 유니코드로 이루어진 것이 아니라, 정규식에서 못잡아내는 문제 존재
- 해당 문제 해결하기 위해 정규식 수정

## 작업 내용
다음과 같은 작업을 완료했음을 확인해주세요:
- [x] 코드가 요구 사항을 충족하는지 확인
- [x] 테스트가 완료되었고, 모든 테스트가 통과함
- [ ] 관련 문서(README, API 문서 등)가 업데이트됨

## 변경된 파일 목록
- `.github/template.txt - 정규식 수정

## 테스트 코드
- [ ] 새로운 기능에 대한 단위 테스트가 작성되었음
- [ ] 기존 기능에 대한 회귀 테스트가 진행되었음

## 체크리스트
PR을 제출하기 전에 다음 항목들을 확인해주세요:
- [x] 코드가 정확하게 동작하는지 확인함
- [x] 코드 스타일과 형식을 준수함
- [x] 의미 있는 커밋 메시지 사용
- [x] 불필요한 코드나 주석이 제거됨
- [] PR에 논의가 필요한 부분이 있는지 확인